### PR TITLE
增强稳定性

### DIFF
--- a/wsgi_monkeytype/flask.py
+++ b/wsgi_monkeytype/flask.py
@@ -14,7 +14,7 @@ class MonkeyType(object):
 
     def init_app(self, app: Flask):
         app.before_request(self.before_request)
-        app.teardown_appcontext(self.teardown)
+        app.teardown_request(self.teardown)
 
     def before_request(self):
         sys.setprofile(self.tracer)


### PR DESCRIPTION
- arg_types/return_type/yield_type 默认使用 mediumtext 保存，避免类型信息过长无法保存
- MySQLStore 写入 mysql 失败时不抛出异常，记录日志
- flask extension 在 request teardown 时保存 monkeytype 数据